### PR TITLE
Moved the gitDescribe.skip configuration value to a property

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -34,6 +34,7 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
         <atomikos-version>3.9.2</atomikos-version>
+        <git.commit.id.describe.skip>false</git.commit.id.describe.skip>
     </properties>
 
     <build>
@@ -55,7 +56,7 @@
                     <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <abbrevLength>7</abbrevLength>
                     <gitDescribe>
-                        <skip>false</skip>
+                        <skip>${git.commit.id.describe.skip}</skip>
                         <always>false</always>
                         <abbrev>7</abbrev>
                         <dirty>-dirty</dirty>


### PR DESCRIPTION
Moved the gitDescribe.skip configuration value to a property so that we can override it using a command line argument. Shallow clones (used by CI builds) cannot provide the expected 'describe' information and the git-commit-id plugin fails to handle it properly.
