### PR TITLE
STASHDEV-7788 Turn `BasicOperationScheduler.responseThread` from a singleton thread into a small thread pool.

### DIFF
--- a/hazelcast-documentation/src/ConfigurationProperties.md
+++ b/hazelcast-documentation/src/ConfigurationProperties.md
@@ -43,6 +43,7 @@ Property Name | Default Value | Type | Description
 `hazelcast.io.thread.count` | 3 | int | Number of input and output threads.
 `hazelcast.operation.thread.count` | -1 | int | Number of partition based operation handler threads. `-1` means CPU core count x 2.
 `hazelcast.operation.generic.thread.count` | -1 | int | Number of generic operation handler threads. `-1` means CPU core count x 2.
+`hazelcast.response.thread.count` | -1 | int | Number of response handler threads. `-1` means CPU core count x 2.
 `hazelcast.event.thread.count` | 5 | int | Number of event handler threads.
 `hazelcast.event.queue.capacity` | 1000000 | int | Capacity of internal event queue.
 `hazelcast.event.queue.timeout.millis` | 250 | int | Timeout to enqueue events to event queue.

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -54,6 +54,7 @@ public class GroupProperties {
      */
     public static final String PROP_PARTITION_OPERATION_THREAD_COUNT = "hazelcast.operation.thread.count";
     public static final String PROP_GENERIC_OPERATION_THREAD_COUNT = "hazelcast.operation.generic.thread.count";
+    public static final String PROP_RESPONSE_THREAD_COUNT = "hazelcast.response.thread.count";
     public static final String PROP_EVENT_THREAD_COUNT = "hazelcast.event.thread.count";
     public static final String PROP_EVENT_QUEUE_CAPACITY = "hazelcast.event.queue.capacity";
     public static final String PROP_EVENT_QUEUE_TIMEOUT_MILLIS = "hazelcast.event.queue.timeout.millis";
@@ -138,6 +139,8 @@ public class GroupProperties {
     public final GroupProperty PARTITION_OPERATION_THREAD_COUNT;
 
     public final GroupProperty GENERIC_OPERATION_THREAD_COUNT;
+
+    public final GroupProperty RESPONSE_THREAD_COUNT;
 
     public final GroupProperty EVENT_THREAD_COUNT;
 
@@ -284,6 +287,7 @@ public class GroupProperties {
         //-1 means that the value is worked out dynamically.
         PARTITION_OPERATION_THREAD_COUNT = new GroupProperty(config, PROP_PARTITION_OPERATION_THREAD_COUNT, "-1");
         GENERIC_OPERATION_THREAD_COUNT = new GroupProperty(config, PROP_GENERIC_OPERATION_THREAD_COUNT, "-1");
+        RESPONSE_THREAD_COUNT = new GroupProperty(config, PROP_RESPONSE_THREAD_COUNT, "-1");
         EVENT_THREAD_COUNT = new GroupProperty(config, PROP_EVENT_THREAD_COUNT, "5");
         EVENT_QUEUE_CAPACITY = new GroupProperty(config, PROP_EVENT_QUEUE_CAPACITY, "1000000");
         EVENT_QUEUE_TIMEOUT_MILLIS = new GroupProperty(config, PROP_EVENT_QUEUE_TIMEOUT_MILLIS, "250");


### PR DESCRIPTION
This is intended to alleviate the observed bottleneck where (according to HealthMonitor stats on one of our
production instances) `executor.q.response.size` and `operations.remote.size` keep growing under heavy load.
