### PR TITLE
gitDescribe.skip

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -34,6 +34,7 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
         <atomikos-version>3.9.2</atomikos-version>
+        <git.commit.id.describe.skip>false</git.commit.id.describe.skip>
     </properties>
 
     <build>
@@ -55,7 +56,7 @@
                     <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <abbrevLength>7</abbrevLength>
                     <gitDescribe>
-                        <skip>false</skip>
+                        <skip>${git.commit.id.describe.skip}</skip>
                         <always>false</always>
                         <abbrev>7</abbrev>
                         <dirty>-dirty</dirty>


### PR DESCRIPTION
Changed hazelcast/pom.xml to move gitDescribe.skip to a property. Now we can override it using a command line variable when working with shallow clones. The git-commit-id plugin does not handle 'git describe' correctly when no data can be retrieved.
