### PR TITLE
STASHDEV-8170: Changed syncPartitionRuntimeState to use all members when...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/proxy/MapProxySupport.java
@@ -234,8 +234,8 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-        return !nodeEngine.getPartitionService().getPartitionOwner(partitionId)
-                .equals(nodeEngine.getClusterService().getThisAddress());
+        return !nodeEngine.getClusterService().getThisAddress()
+                .equals(nodeEngine.getPartitionService().getPartitionOwner(partitionId));
     }
 
     private boolean cacheKeyAnyway() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -168,6 +168,9 @@ public final class Address implements IdentifiedDataSerializable {
 
     @Override
     public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
         if (this == o) {
             return true;
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -1514,7 +1514,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                             currentPartition.setPartitionInfo(replicas);
                         }
                     }
-                    syncPartitionRuntimeState(members);
+                    syncPartitionRuntimeState();
                     logMigrationStatistics(migrationCount, lostCount);
                 } finally {
                     lock.unlock();


### PR DESCRIPTION
STASHDEV-8170: Changed syncPartitionRuntimeState to use all members when creating the runtime state. Changed equals in address to null protect it. Changed notOwnerPartitionForKey in MapProxySupport to null protect it
