### PR TITLE
Stashdev 7788 remove timeout retry logic

### DIFF
--- a/hazelcast-documentation/src/ConfigurationProperties.md
+++ b/hazelcast-documentation/src/ConfigurationProperties.md
@@ -43,7 +43,7 @@ Property Name | Default Value | Type | Description
 `hazelcast.io.thread.count` | 3 | int | Number of input and output threads.
 `hazelcast.operation.thread.count` | -1 | int | Number of partition based operation handler threads. `-1` means CPU core count x 2.
 `hazelcast.operation.generic.thread.count` | -1 | int | Number of generic operation handler threads. `-1` means CPU core count x 2.
-`hazelcast.response.thread.count` | -1 | int | Number of response handler threads. `-1` means CPU core count.
+`hazelcast.response.thread.count` | 1 | int | Number of response handler threads. `-1` means CPU core count.
 `hazelcast.event.thread.count` | 5 | int | Number of event handler threads.
 `hazelcast.event.queue.capacity` | 1000000 | int | Capacity of internal event queue.
 `hazelcast.event.queue.timeout.millis` | 250 | int | Timeout to enqueue events to event queue.

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -287,7 +287,7 @@ public class GroupProperties {
         //-1 means that the value is worked out dynamically.
         PARTITION_OPERATION_THREAD_COUNT = new GroupProperty(config, PROP_PARTITION_OPERATION_THREAD_COUNT, "-1");
         GENERIC_OPERATION_THREAD_COUNT = new GroupProperty(config, PROP_GENERIC_OPERATION_THREAD_COUNT, "-1");
-        RESPONSE_THREAD_COUNT = new GroupProperty(config, PROP_RESPONSE_THREAD_COUNT, "-1");
+        RESPONSE_THREAD_COUNT = new GroupProperty(config, PROP_RESPONSE_THREAD_COUNT, "1");
         EVENT_THREAD_COUNT = new GroupProperty(config, PROP_EVENT_THREAD_COUNT, "5");
         EVENT_QUEUE_CAPACITY = new GroupProperty(config, PROP_EVENT_QUEUE_CAPACITY, "1000000");
         EVENT_QUEUE_TIMEOUT_MILLIS = new GroupProperty(config, PROP_EVENT_QUEUE_TIMEOUT_MILLIS, "250");

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -52,6 +52,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
     private long waitTimeout = -1;
     private String callerUuid;
     private String executorName;
+    private boolean interrupted = false;
 
     // injected
     private transient NodeEngine nodeEngine;
@@ -124,6 +125,15 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
     // Accessed using OperationAccessor
     final Operation setCallId(long callId) {
         this.callId = callId;
+        return this;
+    }
+
+    public boolean getInterrupted() {
+        return interrupted;
+    }
+
+    public final Operation setInterrupted(boolean interrupted) {
+        this.interrupted = interrupted;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
@@ -192,8 +192,7 @@ abstract class BasicInvocation implements ResponseHandler, Runnable {
                 /*
                  * final long minTimeout = Math.min(defaultCallTimeout, MIN_TIMEOUT);
                  * long callTimeout = Math.min(waitTimeoutMillis, defaultCallTimeout);
-                 * callTimeout = Math.max(a, minTimeout);
-                 * return callTimeout;
+                 * return Math.max(callTimeout, minTimeout);
                  *
                  * Below two lines are shortened version of above*
                  * using min(max(x,y),z)=max(min(x,z),min(y,z))

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
@@ -214,6 +214,8 @@ final class BasicInvocationFuture<E> implements InternalCompletableFuture<E> {
                 }
             } catch (InterruptedException e) {
                 interrupted = true;
+                basicInvocation.op.setInterrupted(true);
+                return e;
             }
 
             if (!interrupted && longPolling) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
@@ -152,9 +152,7 @@ public final class BasicOperationScheduler {
         if (op.getCallId() != 0 && op.returnsResponse()) {
             RemoteCallKey callKey = new RemoteCallKey(op);
             if (callKey != null) {
-                if (executingCalls.remove(callKey) == null) {
-                    logger.severe("No Call record has been found: -> " + callKey + " == " + op.getClass().getName());
-                }
+                executingCalls.remove(callKey);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
@@ -149,10 +149,12 @@ public final class BasicOperationScheduler {
     }
 
     public void afterCallExecution(Operation op) {
-        RemoteCallKey callKey = new RemoteCallKey(op);
-        if (callKey != null && op.getCallId() != 0 && op.returnsResponse()) {
-            if (executingCalls.remove(callKey) == null) {
-                logger.severe("No Call record has been found: -> " + callKey + " == " + op.getClass().getName());
+        if (op.getCallId() != 0 && op.returnsResponse()) {
+            RemoteCallKey callKey = new RemoteCallKey(op);
+            if (callKey != null) {
+                if (executingCalls.remove(callKey) == null) {
+                    logger.severe("No Call record has been found: -> " + callKey + " == " + op.getClass().getName());
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -116,7 +116,7 @@ final class BasicOperationService implements InternalOperationService {
     private static final double REMOTE_OPERATION_STATISTICS_THRESHOLD = 0.01;
     private static final int STATISTICS_SPIN_MAX = 3;
 
-    final ConcurrentMap<Long, BasicInvocation> invocations;
+    private final ConcurrentMap<Long, BasicInvocation> invocations;
     final BasicOperationScheduler scheduler;
     private final AtomicLong executedOperationsCount = new AtomicLong();
     private boolean doCountRemoteOperations = false;
@@ -873,10 +873,6 @@ final class BasicOperationService implements InternalOperationService {
 
             RemoteCallKey callKey = null;
             try {
-                if (timeout(op)) {
-                    return;
-                }
-
                 callKey = beforeCallExecution(op);
 
                 ensureNoPartitionProblems(op);
@@ -909,16 +905,6 @@ final class BasicOperationService implements InternalOperationService {
                     nodeEngine.waitNotifyService.await(waitSupport);
                     return true;
                 }
-            }
-            return false;
-        }
-
-        private boolean timeout(Operation op) {
-            if (isCallTimedOut(op)) {
-                Object response = new CallTimeoutException(
-                        op.getClass().getName(), op.getInvocationTime(), op.getCallTimeout());
-                op.getResponseHandler().sendResponse(response);
-                return true;
             }
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -119,6 +119,9 @@ final class BasicOperationService implements InternalOperationService {
     final BasicOperationScheduler scheduler;
     private final AtomicLong executedOperationsCount = new AtomicLong();
     private boolean doCountRemoteOperations = false;
+    private final AtomicLong processedOperationsCount = new AtomicLong();
+    private final AtomicLong processedOperationsLatency = new AtomicLong();
+    private final AtomicLong worstProcessedOperationLatency = new AtomicLong();
     private final AtomicLong executedRemoteOperationsCount = new AtomicLong();
     private final AtomicLong serializationTime = new AtomicLong();
     private final AtomicLong worstSerializationTime = new AtomicLong();
@@ -208,6 +211,14 @@ final class BasicOperationService implements InternalOperationService {
         if (appendAndResetNanos(sb, worstSerializationTime, "worst", worstOperation)) {
             worstOperation = null;
         }
+
+        sb.append(", ");
+        long count = appendAndClear(sb, processedOperationsCount, "processed");
+        if (count != 0) {
+            appendAndClearAverageMillis(sb, processedOperationsLatency, "latency", count);
+            appendAndResetMillis(sb, worstProcessedOperationLatency, "worst");
+        }
+
         return sb.toString();
     }
 
@@ -315,6 +326,22 @@ final class BasicOperationService implements InternalOperationService {
     }
 
     // =============================== processing operation  ===============================
+
+    @PrivateApi
+    public boolean isCallTimedOut(Operation op) {
+        if (op.returnsResponse() && op.getCallId() != 0) {
+            final long callTimeout = op.getCallTimeout();
+            final long invocationTime = op.getInvocationTime();
+            final long expireTime = invocationTime + callTimeout;
+            if (expireTime > 0 && expireTime < Long.MAX_VALUE) {
+                final long now = nodeEngine.getClusterTime();
+                if (expireTime < now) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
     @Override
     public Map<Integer, Object> invokeOnAllPartitions(String serviceName, OperationFactory operationFactory) throws Exception {
@@ -472,6 +499,13 @@ final class BasicOperationService implements InternalOperationService {
         return value;
     }
 
+    // Convenience function for dumping an average counter and clearing it in a thread safe way.
+    private void appendAndClearAverageMillis(StringBuilder sb, AtomicLong counter, String name, long divisor) {
+        long value = counter.get();
+        sb.append(name + "=").append(value / divisor).append("ms, ");
+        counter.addAndGet(-value);
+    }
+
     // Convenience function for dumping a nanosecond counter and clearing it in a thread safe way.
     private void appendAndClearNanos(StringBuilder sb, AtomicLong counter, String name) {
         long value = counter.get();
@@ -479,17 +513,27 @@ final class BasicOperationService implements InternalOperationService {
         counter.addAndGet(-value);
     }
 
-    // Convenience function for dumping a nanosecond latch plus associated data, and resetting in a thread safe way.
+    // Convenience function for dumping a latch and resetting in a thread safe way.
     // The latch is assumed to track the "worst" value of some statistic in some time window, so that if the latch is
     // modified by another thread it must be with another even "worse" value in the next time window - so the latch is
     // not reset.  Returns true if the latch was reset, or false if not.
-    private boolean appendAndResetNanos(StringBuilder sb, AtomicLong latch, String name, Object obj) {
+    private boolean appendAndReset(StringBuilder sb, AtomicLong latch, String name, Object obj, double divisor) {
         long value = latch.get();
-        sb.append(name + "=").append(value / 1000000.0).append("ms");
+        sb.append(name + "=").append(value / divisor).append("ms");
         if (obj != null) {
             sb.append(" - ").append(obj.toString());
         }
         return latch.compareAndSet(value, 0L);
+    }
+
+    // Convenience function for dumping a millisecond latch, and resetting in a thread safe way.
+    private boolean appendAndResetMillis(StringBuilder sb, AtomicLong latch, String name) {
+        return appendAndReset(sb, latch, name, null, 1.0);
+    }
+
+    // Convenience function for dumping a nanosecond latch plus associated data, and resetting in a thread safe way.
+    private boolean appendAndResetNanos(StringBuilder sb, AtomicLong latch, String name, Object obj) {
+        return appendAndReset(sb, latch, name, obj, 1000000.0);
     }
 
     private static String getNameOfOperation(Operation op) {
@@ -508,7 +552,34 @@ final class BasicOperationService implements InternalOperationService {
         return name;
     }
 
-    // Record various statistics for an Operation.
+    // Record various statistics for a processed Operation.
+    private void countProcessedOperation(Operation op) {
+        if (!doCountRemoteOperations) {
+            return;
+        }
+        long invocationTime = op.getInvocationTime();
+        if (invocationTime < 0) {
+            // We are only interested in Operations with valid invocationTimes
+            return;
+        }
+        Address callerAddress = op.getCallerAddress();
+        if (callerAddress == null || callerAddress.equals(nodeEngine.getThisAddress())) {
+            // We are only interested in Operations from remote nodes.
+            return;
+        }
+        long latency = invocationTime - nodeEngine.getClusterTime();
+        processedOperationsCount.incrementAndGet();
+        processedOperationsLatency.addAndGet(latency);
+        long worstProcessedOperationLatencyValue;
+        for (int i = 0; (worstProcessedOperationLatencyValue = worstProcessedOperationLatency.longValue()) < latency &&
+                i < STATISTICS_SPIN_MAX; i++) {
+            if (worstProcessedOperationLatency.compareAndSet(worstProcessedOperationLatencyValue, latency)) {
+                break;
+            }
+        }
+    }
+
+    // Record various statistics for an Operation sent to a remote node.
     private void countRemoteOperation(Operation op, long time, int bufferSize) {
         if (!doCountRemoteOperations) {
             return;
@@ -524,6 +595,7 @@ final class BasicOperationService implements InternalOperationService {
                 i < STATISTICS_SPIN_MAX; i++) {
             if (worstSerializationTime.compareAndSet(worstSerializationTimeValue, time)) {
                 worstOperation = name;
+                break;
             }
         }
 
@@ -854,6 +926,11 @@ final class BasicOperationService implements InternalOperationService {
         private void handle(Operation op) {
             if (op.getInterrupted()) {
                 return;
+            }
+
+            countProcessedOperation(op);
+            if (isCallTimedOut(op)) {
+                logger.warning("Processing expired operation: " + op.toString());
             }
 
             executedOperationsCount.incrementAndGet();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -49,7 +49,6 @@ import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.WaitSupport;
 import com.hazelcast.spi.annotation.PrivateApi;
-import com.hazelcast.spi.exception.CallTimeoutException;
 import com.hazelcast.spi.exception.CallerNotMemberException;
 import com.hazelcast.spi.exception.PartitionMigratingException;
 import com.hazelcast.spi.exception.WrongTargetException;
@@ -316,22 +315,6 @@ final class BasicOperationService implements InternalOperationService {
     }
 
     // =============================== processing operation  ===============================
-
-    @PrivateApi
-    public boolean isCallTimedOut(Operation op) {
-        if (op.returnsResponse() && op.getCallId() != 0) {
-            final long callTimeout = op.getCallTimeout();
-            final long invocationTime = op.getInvocationTime();
-            final long expireTime = invocationTime + callTimeout;
-            if (expireTime > 0 && expireTime < Long.MAX_VALUE) {
-                final long now = nodeEngine.getClusterTime();
-                if (expireTime < now) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
 
     @Override
     public Map<Integer, Object> invokeOnAllPartitions(String serviceName, OperationFactory operationFactory) throws Exception {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -928,15 +928,15 @@ final class BasicOperationService implements InternalOperationService {
                 return;
             }
 
-            countProcessedOperation(op);
-            if (isCallTimedOut(op)) {
-                logger.warning("Processing expired operation: " + op.toString());
-            }
-
             executedOperationsCount.incrementAndGet();
 
             RemoteCallKey callKey = null;
             try {
+                if (isCallTimedOut(op)) {
+                    logger.warning("Processing expired operation: " + op.toString());
+                }
+                countProcessedOperation(op);
+
                 callKey = beforeCallExecution(op);
 
                 ensureNoPartitionProblems(op);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -852,6 +852,10 @@ final class BasicOperationService implements InternalOperationService {
          * Runs operation in calling thread.
          */
         private void handle(Operation op) {
+            if (op.getInterrupted()) {
+                return;
+            }
+
             executedOperationsCount.incrementAndGet();
 
             RemoteCallKey callKey = null;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
@@ -32,8 +32,6 @@ public interface InternalOperationService extends OperationService {
 
     void onMemberLeft(MemberImpl member);
 
-    boolean isCallTimedOut(Operation op);
-
     void notifyBackupCall(long callId);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/RemoteCallKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/RemoteCallKey.java
@@ -1,0 +1,77 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.util.Clock;
+
+/**
+ * Created by csmajda on 14/11/2014.
+ */
+public final class RemoteCallKey {
+    private final long time = Clock.currentTimeMillis();
+    // human readable caller
+    private final Address callerAddress;
+    private final String callerUuid;
+    private final long callId;
+
+    public RemoteCallKey(Address callerAddress, String callerUuid, long callId) {
+        if (callerUuid == null) {
+            throw new IllegalArgumentException("Caller UUID is required!");
+        }
+        this.callerAddress = callerAddress;
+        if (callerAddress == null) {
+            throw new IllegalArgumentException("Caller address is required!");
+        }
+        this.callerUuid = callerUuid;
+        this.callId = callId;
+    }
+
+    public RemoteCallKey(final Operation op) {
+        callerUuid = op.getCallerUuid();
+        if (callerUuid == null) {
+            throw new IllegalArgumentException("Caller UUID is required! -> " + op);
+        }
+        callerAddress = op.getCallerAddress();
+        if (callerAddress == null) {
+            throw new IllegalArgumentException("Caller address is required! -> " + op);
+        }
+        callId = op.getCallId();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RemoteCallKey callKey = (RemoteCallKey) o;
+        if (callId != callKey.callId) {
+            return false;
+        }
+        if (!callerUuid.equals(callKey.callerUuid)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = callerUuid.hashCode();
+        result = 31 * result + (int) (callId ^ (callId >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("RemoteCallKey");
+        sb.append("{callerAddress=").append(callerAddress);
+        sb.append(", callerUuid=").append(callerUuid);
+        sb.append(", callId=").append(callId);
+        sb.append(", time=").append(time);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
@@ -263,7 +263,7 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
         }
 
         public boolean needsInvalidation() {
-            return isExpired() || isCancelled() || isCallTimedOut();
+            return isExpired() || isCancelled();
         }
 
         public boolean isExpired() {
@@ -272,15 +272,6 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
 
         public boolean isCancelled() {
             return error != null;
-        }
-
-        public boolean isCallTimedOut() {
-            final NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-            if (nodeEngine.operationService.isCallTimedOut(op)) {
-                cancel(new CallTimeoutException(op.getClass().getName(), op.getInvocationTime(), op.getCallTimeout()));
-                return true;
-            }
-            return false;
         }
 
         public boolean shouldWait() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
@@ -29,7 +29,6 @@ import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitNotifyService;
 import com.hazelcast.spi.WaitSupport;
-import com.hazelcast.spi.exception.CallTimeoutException;
 import com.hazelcast.spi.exception.PartitionMigratingException;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.util.Clock;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/BasicOperationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/BasicOperationServiceTest.java
@@ -220,7 +220,7 @@ public class BasicOperationServiceTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertEquals("invocations should be empty", 0, operationService.invocations.size());
+                assertEquals("invocations should be empty", 0, operationService.getRemoteOperationsCount());
              }
         });
     }


### PR DESCRIPTION
This is a replay of https://github.com/atlassian/hazelcast/pull/18 on the `atlassian-integration` branch.
Remove the code to send CallTimeoutException responses from remote operation threads back to the caller to indicate timeout.
These are expensive to deserialize (especially when the contents of the CallTimeoutException are not used for anything anyway), and when
the queue is long can lead to an indefinitely growing queue of retried invocations.
In addition, fix the `IsStillExecutingOperation` to return true when a remote call is stuck in one of the work queues but not yet being acted on by one of the operation threads.