### PR TITLE
ADM-62937 Make heartbeater resilient to clock tampering.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterServiceImpl.java
@@ -282,7 +282,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
          */
         long clockJump = 0L;
         if (lastHeartBeat != 0L) {
-            clockJump = now - lastHeartBeat - heartbeatInterval;
+            clockJump = now - lastHeartBeat - TimeUnit.SECONDS.toMillis(heartbeatInterval);
             if (Math.abs(clockJump) > 5000L) {
                 SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
                 logger.warning("System clock jumped from " + sdf.format(new Date(lastHeartBeat)) + " to " +


### PR DESCRIPTION
If the system clock changes by more than the heartbeat interval (default 1000ms)
between heartbeats, then compensate for this one-off difference before removing
members from the cluster.  Also log a warning if the clock jump is > 5000ms.
