### PR TITLE
STASHDEV-9827 Fix LOCAL mode hibernate caching.

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
@@ -53,7 +53,7 @@ public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegi
     public CollectionRegion buildCollectionRegion(final String regionName, final Properties properties,
                                                   final CacheDataDescription metadata) throws CacheException {
         final HazelcastCollectionRegion<LocalRegionCache> region = new HazelcastCollectionRegion<LocalRegionCache>(instance,
-                regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
+                regionName, properties, metadata, new LocalRegionCache(regionName, instance, null));
         cleanupService.registerCache(region.getCache());
         return region;
     }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/AbstractAccessDelegate.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/AbstractAccessDelegate.java
@@ -57,29 +57,6 @@ public abstract class AbstractAccessDelegate<T extends HazelcastRegion> implemen
         return hazelcastRegion;
     }
 
-    public boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException {
-        try {
-            return cache.insert(key, value, version);
-        } catch (HazelcastException e) {
-            if (log.isFinestEnabled()) {
-                log.finest("Could not insert into Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
-            }
-            return false;
-        }
-    }
-
-    protected boolean update(final Object key, final Object value,
-                             final Object currentVersion, final SoftLock lock) {
-        try {
-            return cache.update(key, value, currentVersion, lock);
-        } catch (HazelcastException e) {
-            if (log.isFinestEnabled()) {
-                log.finest("Could not update Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
-            }
-            return false;
-        }
-    }
-
     public Object get(final Object key, final long txTimestamp) throws CacheException {
         try {
             return cache.get(key, txTimestamp);
@@ -108,19 +85,8 @@ public abstract class AbstractAccessDelegate<T extends HazelcastRegion> implemen
         return putFromLoad(key, value, txTimestamp, version);
     }
 
-    /**
-     * This is an asynchronous cache access strategy.
-     * NO-OP
-     */
-    public void remove(final Object key) throws CacheException {
-    }
-
-    public void removeAll() throws CacheException {
-        cache.clear();
-    }
-
     public void evict(final Object key) throws CacheException {
-        remove(key);
+        cache.remove(key);
     }
 
     public void evictAll() throws CacheException {
@@ -135,24 +101,6 @@ public abstract class AbstractAccessDelegate<T extends HazelcastRegion> implemen
     }
 
     public void unlockRegion(final SoftLock lock) throws CacheException {
-        // As a precaution
         cache.clear();
-    }
-
-    /**
-     * This is an asynchronous cache access strategy.
-     * NO-OP
-     */
-    public boolean insert(final Object key, final Object value, final Object version) throws CacheException {
-        return false;
-    }
-
-    /**
-     * This is an asynchronous cache access strategy.
-     * NO-OP
-     */
-    public boolean update(final Object key, final Object value, final Object currentVersion, final Object previousVersion)
-            throws CacheException {
-        return false;
     }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/AccessDelegate.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/AccessDelegate.java
@@ -43,7 +43,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * @param txTimestamp a timestamp prior to the transaction start time
      * @return the cached object or <tt>null</tt>
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     Object get(Object key, long txTimestamp) throws CacheException;
 
@@ -57,7 +57,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * @param version The item's version value
      * @return Were the contents of the cache actual changed by this operation?
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     boolean insert(Object key, Object value, Object version) throws CacheException;
 
@@ -71,7 +71,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * @param version The item's version value
      * @return Were the contents of the cache actual changed by this operation?
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     boolean afterInsert(Object key, Object value, Object version) throws CacheException;
 
@@ -86,7 +86,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * @param previousVersion The item's previous version value
      * @return Were the contents of the cache actual changed by this operation?
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     boolean update(Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException;
 
@@ -102,7 +102,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * @param lock            The lock previously obtained from {@link #lockItem}
      * @return Were the contents of the cache actual changed by this operation?
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
             throws CacheException;
@@ -116,7 +116,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * @param version     the item version number
      * @return <tt>true</tt> if the object was successfully cached
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException;
 
@@ -131,7 +131,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * @param minimalPutOverride Explicit minimalPut flag
      * @return <tt>true</tt> if the object was successfully cached
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
             throws CacheException;
@@ -142,7 +142,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      *
      * @param key The key of the item to remove
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     void remove(Object key) throws CacheException;
 
@@ -150,7 +150,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * Called to evict data from the entire region
      *
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     void removeAll() throws CacheException;
 
@@ -160,7 +160,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      *
      * @param key The key of the item to remove
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     void evict(Object key) throws CacheException;
 
@@ -169,7 +169,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * isolation.
      *
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     void evictAll() throws CacheException;
 
@@ -185,7 +185,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * @param version The item's current version value
      * @return A representation of our lock on the item; or null.
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     SoftLock lockItem(Object key, Object version) throws CacheException;
 
@@ -194,7 +194,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      *
      * @return A representation of our lock on the item; or null.
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     SoftLock lockRegion() throws CacheException;
 
@@ -206,7 +206,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      * @param key  The item key
      * @param lock The lock previously obtained from {@link #lockItem}
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     void unlockItem(Object key, SoftLock lock) throws CacheException;
 
@@ -216,7 +216,7 @@ public interface AccessDelegate<T extends HazelcastRegion> {
      *
      * @param lock The lock previously obtained from {@link #lockRegion}
      * @throws org.hibernate.cache.CacheException
-     *          Propogated from underlying {@link org.hibernate.cache.spi.Region}
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
      */
     void unlockRegion(SoftLock lock) throws CacheException;
 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/NonStrictReadWriteAccessDelegate.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/NonStrictReadWriteAccessDelegate.java
@@ -36,9 +36,38 @@ public class NonStrictReadWriteAccessDelegate<T extends HazelcastRegion> extends
         super(hazelcastRegion, props);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Returns <code>false</code> since this is a non-strict read/write cache access strategy
+     */
+    public boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
     public boolean afterUpdate(final Object key, final Object value, final Object currentVersion, final Object previousVersion,
                                final SoftLock lock) throws CacheException {
-        return update(key, value, currentVersion, lock);
+        unlockItem(key, lock);
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Returns <code>false</code> since this is an asynchronous cache access strategy.
+     */
+    public boolean insert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Removes the entry since this is a non-strict read/write cache strategy.
+     */
+    public boolean update(final Object key, final Object value, final Object currentVersion, final Object previousVersion) {
+        remove(key);
+        return false;
     }
 
     @Override
@@ -54,11 +83,11 @@ public class NonStrictReadWriteAccessDelegate<T extends HazelcastRegion> extends
         return null;
     }
 
-    public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
-        remove(key);
+    public void removeAll() throws CacheException {
+        cache.clear();
     }
 
-    public void unlockRegion(final SoftLock lock) throws CacheException {
-        removeAll();
+    public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
+        remove(key);
     }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
@@ -77,10 +77,16 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
     }
 
     /**
-     * This will issue a log warning stating that an attempt was made to unlock an item from a read-only cache region.
+     * {@inheritDoc}
+     * <p/>
+     * Should be a no-op since this cache is read-only
      */
     @Override
     public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
+        /*
+         * To err on the safe side though, follow ReadOnlyEhcacheEntityRegionAccessStrategy which nevertheless evicts
+         * the key.
+         */
         evict(key);
     }
 

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
@@ -34,6 +34,11 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
         super(hazelcastRegion, props);
     }
 
+    @Override
+    public boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException {
+        return cache.insert(key, value, version);
+    }
+
     /**
      * @throws UnsupportedOperationException
      */
@@ -45,12 +50,17 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
     }
 
     /**
-     * @throws UnsupportedOperationException
+     * {@inheritDoc}
+     * <p/>
+     * This cache is asynchronous hence a no-op
      */
+    public boolean insert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
     @Override
     public SoftLock lockItem(final Object key, final Object version) throws CacheException {
-        throw new UnsupportedOperationException("Attempting to lock an item in a read-only cache region: "
-                + getHazelcastRegion().getName());
+        return null;
     }
 
     /**
@@ -62,12 +72,16 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
                 + getHazelcastRegion().getName());
     }
 
+    public void removeAll() throws CacheException {
+        cache.clear();
+    }
+
     /**
      * This will issue a log warning stating that an attempt was made to unlock an item from a read-only cache region.
      */
     @Override
     public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
-        log.warning("Attempting to unlock an item from a read-only cache region");
+        evict(key);
     }
 
     /**

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/ReadWriteAccessDelegate.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/access/ReadWriteAccessDelegate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.hibernate.access;
 
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.hibernate.region.HazelcastRegion;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -35,6 +36,17 @@ public class ReadWriteAccessDelegate<T extends HazelcastRegion> extends Abstract
         super(hazelcastRegion, props);
     }
 
+    public boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException {
+        try {
+            return cache.insert(key, value, version);
+        } catch (HazelcastException e) {
+            if (log.isFinestEnabled()) {
+                log.finest("Could not insert into Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
+            }
+            return false;
+        }
+    }
+
     /**
      * {@inheritDoc}
      * <p/>
@@ -43,10 +55,21 @@ public class ReadWriteAccessDelegate<T extends HazelcastRegion> extends Abstract
     public boolean afterUpdate(final Object key, final Object value, final Object currentVersion, final Object previousVersion,
                                final SoftLock lock) throws CacheException {
         try {
-            return update(key, value, currentVersion, lock);
-        } finally {
-            unlockItem(key, lock);
+            return cache.update(key, value, currentVersion, lock);
+        } catch (HazelcastException e) {
+            if (log.isFinestEnabled()) {
+                log.finest("Could not update Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
+            }
+            return false;
         }
+    }
+
+    /**
+     * This is an asynchronous cache access strategy.
+     * NO-OP
+     */
+    public boolean insert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
     }
 
     public SoftLock lockItem(final Object key, final Object version) throws CacheException {
@@ -57,6 +80,29 @@ public class ReadWriteAccessDelegate<T extends HazelcastRegion> extends Abstract
         cache.unlock(key, lock);
     }
 
-    public void unlockRegion(SoftLock lock) throws CacheException {
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * A no-op since this is an asynchronous cache access strategy.
+     */
+    @Override
+    public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+            throws CacheException {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * A no-op since this is an asynchronous cache access strategy.
+     */
+    public void remove(final Object key) throws CacheException {
+    }
+
+    /**
+     * This is an asynchronous cache access strategy.
+     * NO-OP
+     */
+    public void removeAll() throws CacheException {
     }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -202,7 +202,7 @@ public class LocalRegionCache implements RegionCache {
 
     public boolean remove(final Object key) {
         final Expirable value = cache.remove(key);
-        maybeNotifyTopic(key, null, (value != null) ? value.getVersion() : null);
+        maybeNotifyTopic(key, null, (value == null) ? null : value.getVersion());
         return (value != null);
     }
 
@@ -309,9 +309,8 @@ public class LocalRegionCache implements RegionCache {
                 if (value != null) {
                     Object newVersion = invalidation.getVersion();
                     if (newVersion == null) {
-                        // This invalidation was either for an entity with unknown version OR for a collection (which
-                        // are unversioned) relating to an entity with a valid versionComparator.  Just invalidate the
-                        // key unconditionally.
+                        // This invalidation was for an entity with unknown version.  Just invalidate the entry
+                        // unconditionally.
                         cache.remove(key);
                     } else {
                         // Invalidate the entry only if it was of a lower version.

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -303,8 +303,8 @@ public class LocalRegionCache implements RegionCache {
                 // For an unversioned entity or collection we can only invalidate the entry.
                 cache.remove(key);
             } else {
-                // For versioned entities we can avoid the invalidation if both we and the remote node know the version
-                // and our version is definitely equal or higher.  Otherwise, we have to just invalidate our entry.
+                // For versioned entities we can avoid the invalidation if both we and the remote node know the version,
+                // AND our version is definitely equal or higher.  Otherwise, we have to just invalidate our entry.
                 final Expirable value = cache.get(key);
                 if (value != null) {
                     Object newVersion = invalidation.getVersion();
@@ -313,9 +313,9 @@ public class LocalRegionCache implements RegionCache {
                         // unconditionally.
                         cache.remove(key);
                     } else {
-                        // Invalidate the entry only if it was of a lower version.
+                        // Invalidate our entry only if it was of a lower version.
                         Object currentVersion = value.getVersion();
-                        if (versionComparator.compare(newVersion, currentVersion) < 0) {
+                        if (versionComparator.compare(currentVersion, newVersion) < 0) {
                             cache.remove(key, value);
                         }
                     }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -24,20 +24,16 @@ import com.hazelcast.core.MessageListener;
 import com.hazelcast.hibernate.CacheEnvironment;
 import com.hazelcast.hibernate.HazelcastTimestamper;
 import com.hazelcast.hibernate.RegionCache;
-import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.util.Clock;
 import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.access.SoftLock;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -60,6 +56,8 @@ public class LocalRegionCache implements RegionCache {
     protected final Comparator versionComparator;
     protected final AtomicLong markerIdCounter;
     protected MapConfig config;
+
+    private final ILogger log = Logger.getLogger(LocalRegionCache.class);
 
     /**
      * @param name              the name for this region cache, which is also used to retrieve configuration/topic
@@ -91,7 +89,7 @@ public class LocalRegionCache implements RegionCache {
         try {
             config = hazelcastInstance != null ? hazelcastInstance.getConfig().findMapConfig(name) : null;
         } catch (UnsupportedOperationException e) {
-            Logger.getLogger(LocalRegionCache.class).finest(e);
+            log.finest(e);
         }
         versionComparator = metadata != null && metadata.isVersioned() ? metadata.getVersionComparator() : null;
         cache = new ConcurrentHashMap<Object, Expirable>();
@@ -127,11 +125,11 @@ public class LocalRegionCache implements RegionCache {
                 }
             } else if (previous.isReplaceableBy(txTimestamp, version, versionComparator)) {
                 if (cache.replace(key, previous, newValue)) {
-        return true;
-    }
+                    return true;
+                }
             } else {
-            return false;
-        }
+                return false;
+            }
         }
     }
 
@@ -195,18 +193,28 @@ public class LocalRegionCache implements RegionCache {
     protected MessageListener<Object> createMessageListener() {
         return new MessageListener<Object>() {
             public void onMessage(final Message<Object> message) {
+                if (message.getPublishingMember().localMember()) {
+                    return;
+                }
                 final Invalidation invalidation = (Invalidation) message.getMessageObject();
-                if (versionComparator != null) {
-                    final Expirable value = cache.get(invalidation.getKey());
-                    if (value != null) {
-                        Object currentVersion = value.getVersion();
-                        Object newVersion = invalidation.getVersion();
-                        if (versionComparator.compare(newVersion, currentVersion) > 0) {
-                            cache.remove(invalidation.getKey(), value);
+                Object key = invalidation.getKey();
+                if (key != null) {
+                    if (versionComparator != null) {
+                        final Expirable value = cache.get(key);
+                        if (value != null) {
+                            Object newVersion = invalidation.getVersion();
+                            if (newVersion != null) {
+                                Object currentVersion = value.getVersion();
+                                if (versionComparator.compare(newVersion, currentVersion) > 0) {
+                                    cache.remove(key, value);
+                                    return;
+                                }
+                            }
                         }
                     }
+                    cache.remove(key);
                 } else {
-                    cache.remove(invalidation.getKey());
+                    cache.clear();
                 }
             }
         };
@@ -214,11 +222,8 @@ public class LocalRegionCache implements RegionCache {
 
     public boolean remove(final Object key) {
         final Expirable value = cache.remove(key);
-        if (value != null) {
-            maybeNotifyTopic(key, null, value.getVersion());
-            return true;
-        }
-        return false;
+        maybeNotifyTopic(key, null, (value != null) ? value.getVersion() : null);
+        return (value != null);
     }
 
     public SoftLock tryLock(final Object key, final Object version) {
@@ -262,6 +267,7 @@ public class LocalRegionCache implements RegionCache {
                 break;
             }
         }
+        maybeNotifyTopic(key, null, null);
     }
 
     public boolean contains(final Object key) {
@@ -270,6 +276,7 @@ public class LocalRegionCache implements RegionCache {
 
     public void clear() {
         cache.clear();
+        maybeNotifyTopic(null, null, null);
     }
 
     public long size() {

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -194,7 +194,7 @@ public class LocalRegionCache implements RegionCache {
         return new MessageListener<Object>() {
             public void onMessage(final Message<Object> message) {
                 if (!message.getPublishingMember().localMember()) {
-                    maybeInvalidate((Invalidation) message.getMessageObject());
+                    maybeInvalidate(message.getMessageObject());
                 }
             }
         };
@@ -293,7 +293,8 @@ public class LocalRegionCache implements RegionCache {
         }
     }
 
-    private void maybeInvalidate(Invalidation invalidation) {
+    protected void maybeInvalidate(final Object messageObject) {
+        Invalidation invalidation = (Invalidation) messageObject;
         Object key = invalidation.getKey();
         if (key == null) {
             // Invalidate the entire region cache.

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/TimestampsRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/TimestampsRegionCache.java
@@ -17,8 +17,6 @@
 package com.hazelcast.hibernate.local;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
 import com.hazelcast.hibernate.RegionCache;
 import com.hazelcast.hibernate.serialization.Expirable;
 import com.hazelcast.hibernate.serialization.Value;
@@ -43,33 +41,29 @@ public class TimestampsRegionCache extends LocalRegionCache implements RegionCac
     }
 
     @Override
-    protected MessageListener<Object> createMessageListener() {
-        return new MessageListener<Object>() {
-            public void onMessage(final Message<Object> message) {
-                final Timestamp ts = (Timestamp) message.getMessageObject();
-                final Object key = ts.getKey();
+    protected void maybeInvalidate(final Object messageObject) {
+        final Timestamp ts = (Timestamp) messageObject;
+        final Object key = ts.getKey();
 
-                for (;;) {
-                    final Expirable value = cache.get(key);
-                    final Long current = value != null ? (Long) value.getValue() : null;
-                    if (current != null) {
-                        if (ts.getTimestamp() > current) {
-                            if (cache.replace(key, value, new Value(value.getVersion(),
-                                    Clock.currentTimeMillis(), ts.getTimestamp()))) {
-                                return;
-                            }
-                        } else {
-                            return;
-                        }
-                    } else {
-                        if (cache.putIfAbsent(key, new Value(null, Clock.currentTimeMillis(),
-                                ts.getTimestamp())) == null) {
-                            return;
-                        }
+        for (;;) {
+            final Expirable value = cache.get(key);
+            final Long current = value != null ? (Long) value.getValue() : null;
+            if (current != null) {
+                if (ts.getTimestamp() > current) {
+                    if (cache.replace(key, value, new Value(value.getVersion(),
+                            Clock.currentTimeMillis(), ts.getTimestamp()))) {
+                        return;
                     }
+                } else {
+                    return;
+                }
+            } else {
+                if (cache.putIfAbsent(key, new Value(null, Clock.currentTimeMillis(),
+                        ts.getTimestamp())) == null) {
+                    return;
                 }
             }
-        };
+        }
     }
 
     @Override


### PR DESCRIPTION
 * Rework `AbstractAccessDelegate` to factor out only the common
   methods between the various `Delegate` classes.
 * Truly implement READ_COMMITTED transactional semantics (i.e.,
   handle `insert`, `update`, and `remove` as no-ops, and only
   apply modifications to the cache on `afterInsert`,
   `afterUpdate` and `unlockItem`) in all asynchronous cache
   access strategies.
 * For completeness, implement `NonStrictReadWrite` and `ReadOnly`
   AccessDelegates roughly the same as their counterparts in
   EHCache.
 * In `LocalRegionCache`, improve handling of invalidations in the
   following cases:
    - post-commit deletion (in `unlockItem`),
    - Collections that have a `VersionComparator` but null version,
    - bulk / multi-table updates (in `unlockRegion`).
 * Nodes do not have to listen to their own events published on the
   TopicService.