### PR TITLE
STASHDEV-9784 MultiExecutionCallback race problem

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterFactory.java
@@ -55,8 +55,8 @@ class ExecutionCallbackAdapterFactory {
     private void onResponse(Member member, Object response) {
         assertNotDone();
         assertIsMember(member);
-        placeResponse(member, response);
         triggerOnResponse(member, response);
+        placeResponse(member, response);
         triggerOnComplete();
     }
 


### PR DESCRIPTION
STASHDEV-9784 MultiExecutionCallback race problem
This backports the essential part of https://github.com/hazelcast/hazelcast/pull/5492/files into https://github.com/atlassian/hazelcast/tree/3.4.2-atlassian.
The fix plus unit test are already on 3.5.0-atlassian (commited by Peter Veentjer), but not yet on 3.4.2-atlassian due to conflicts. 