### PR TITLE
STASHDEV-9902 Fix Hibernate caching of natural id regions in LOCAL cache mode

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -20,13 +20,11 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.instance.HazelcastInstanceFactory;
 import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;
 import com.hazelcast.hibernate.local.CleanupService;
-import com.hazelcast.hibernate.region.HazelcastNaturalIdRegion;
 import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.CacheDataDescription;
-import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.QueryResultsRegion;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.access.AccessType;
@@ -62,12 +60,6 @@ public abstract class AbstractHazelcastCacheRegionFactory implements RegionFacto
         HazelcastQueryResultsRegion region = new HazelcastQueryResultsRegion(instance, regionName, properties);
         cleanupService.registerCache(region.getCache());
         return region;
-    }
-
-    public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties
-            , final CacheDataDescription metadata)
-            throws CacheException {
-        return new HazelcastNaturalIdRegion(instance, regionName, properties, metadata);
     }
 
     /**

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
@@ -20,13 +20,10 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.distributed.IMapRegionCache;
 import com.hazelcast.hibernate.region.HazelcastCollectionRegion;
 import com.hazelcast.hibernate.region.HazelcastEntityRegion;
+import com.hazelcast.hibernate.region.HazelcastNaturalIdRegion;
 import com.hazelcast.hibernate.region.HazelcastTimestampsRegion;
 import org.hibernate.cache.CacheException;
-import org.hibernate.cache.spi.RegionFactory;
-import org.hibernate.cache.spi.CacheDataDescription;
-import org.hibernate.cache.spi.CollectionRegion;
-import org.hibernate.cache.spi.EntityRegion;
-import org.hibernate.cache.spi.TimestampsRegion;
+import org.hibernate.cache.spi.*;
 
 import java.util.Properties;
 
@@ -56,6 +53,13 @@ public class HazelcastCacheRegionFactory extends AbstractHazelcastCacheRegionFac
                                           final CacheDataDescription metadata) throws CacheException {
         return new HazelcastEntityRegion<IMapRegionCache>(instance, regionName, properties, metadata,
                 new IMapRegionCache(regionName, instance, properties, metadata));
+    }
+
+    public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties,
+                                                final CacheDataDescription metadata)
+            throws CacheException {
+        return new HazelcastNaturalIdRegion<IMapRegionCache>(instance, regionName, properties, metadata,
+                new IMapRegionCache(regionName, instance, properties, null));
     }
 
     public TimestampsRegion buildTimestampsRegion(final String regionName, final Properties properties)

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
@@ -45,8 +45,9 @@ public class HazelcastCacheRegionFactory extends AbstractHazelcastCacheRegionFac
 
     public CollectionRegion buildCollectionRegion(final String regionName, final Properties properties,
                                                   final CacheDataDescription metadata) throws CacheException {
+        /* Collection regions are never versioned, so pass in null for metadata */
         return new HazelcastCollectionRegion<IMapRegionCache>(instance, regionName, properties, metadata,
-                new IMapRegionCache(regionName, instance, properties, metadata));
+                new IMapRegionCache(regionName, instance, properties, null));
     }
 
     public EntityRegion buildEntityRegion(final String regionName, final Properties properties,
@@ -58,6 +59,7 @@ public class HazelcastCacheRegionFactory extends AbstractHazelcastCacheRegionFac
     public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties,
                                                 final CacheDataDescription metadata)
             throws CacheException {
+        /* Natural id regions are never versioned, so pass in null for metadata */
         return new HazelcastNaturalIdRegion<IMapRegionCache>(instance, regionName, properties, metadata,
                 new IMapRegionCache(regionName, instance, properties, null));
     }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
@@ -49,6 +49,7 @@ public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegi
 
     public CollectionRegion buildCollectionRegion(final String regionName, final Properties properties,
                                                   final CacheDataDescription metadata) throws CacheException {
+        /* Collection regions are never versioned, so pass in null for metadata */
         final HazelcastCollectionRegion<LocalRegionCache> region = new HazelcastCollectionRegion<LocalRegionCache>(instance,
                 regionName, properties, metadata, new LocalRegionCache(regionName, instance, null));
         cleanupService.registerCache(region.getCache());
@@ -66,8 +67,9 @@ public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegi
     public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties
             , final CacheDataDescription metadata)
             throws CacheException {
-        final HazelcastNaturalIdRegion<LocalRegionCache> region = new HazelcastNaturalIdRegion<LocalRegionCache>(instance,
-                regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
+        /* Natural id regions are never versioned, so pass in null for metadata */
+        HazelcastNaturalIdRegion<LocalRegionCache> region = new HazelcastNaturalIdRegion<LocalRegionCache>(instance,
+                regionName, properties, metadata, new LocalRegionCache(regionName, instance, null));
         cleanupService.registerCache(region.getCache());
         return region;
     }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
@@ -21,13 +21,10 @@ import com.hazelcast.hibernate.local.LocalRegionCache;
 import com.hazelcast.hibernate.local.TimestampsRegionCache;
 import com.hazelcast.hibernate.region.HazelcastCollectionRegion;
 import com.hazelcast.hibernate.region.HazelcastEntityRegion;
+import com.hazelcast.hibernate.region.HazelcastNaturalIdRegion;
 import com.hazelcast.hibernate.region.HazelcastTimestampsRegion;
 import org.hibernate.cache.CacheException;
-import org.hibernate.cache.spi.CacheDataDescription;
-import org.hibernate.cache.spi.CollectionRegion;
-import org.hibernate.cache.spi.EntityRegion;
-import org.hibernate.cache.spi.RegionFactory;
-import org.hibernate.cache.spi.TimestampsRegion;
+import org.hibernate.cache.spi.*;
 
 import java.util.Properties;
 
@@ -61,6 +58,15 @@ public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegi
     public EntityRegion buildEntityRegion(final String regionName, final Properties properties,
                                           final CacheDataDescription metadata) throws CacheException {
         final HazelcastEntityRegion<LocalRegionCache> region = new HazelcastEntityRegion<LocalRegionCache>(instance,
+                regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
+        cleanupService.registerCache(region.getCache());
+        return region;
+    }
+
+    public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties
+            , final CacheDataDescription metadata)
+            throws CacheException {
+        final HazelcastNaturalIdRegion<LocalRegionCache> region = new HazelcastNaturalIdRegion<LocalRegionCache>(instance,
                 regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
         cleanupService.registerCache(region.getCache());
         return region;

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/region/HazelcastNaturalIdRegion.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/region/HazelcastNaturalIdRegion.java
@@ -17,6 +17,7 @@
 package com.hazelcast.hibernate.region;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
 import com.hazelcast.hibernate.access.NonStrictReadWriteAccessDelegate;
 import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
 import com.hazelcast.hibernate.access.ReadWriteAccessDelegate;
@@ -32,12 +33,12 @@ import java.util.Properties;
 /**
  * Hazelcast based implementation used to store NaturalIds
  */
-public class HazelcastNaturalIdRegion extends AbstractTransactionalDataRegion<IMapRegionCache>
+public class HazelcastNaturalIdRegion<Cache extends RegionCache> extends AbstractTransactionalDataRegion<Cache>
         implements NaturalIdRegion {
 
     public HazelcastNaturalIdRegion(final HazelcastInstance instance, final String regionName,
-                                    final Properties props, final CacheDataDescription metadata) {
-        super(instance, regionName, props, metadata, new IMapRegionCache(regionName, instance, props, metadata));
+                                    final Properties props, final CacheDataDescription metadata, final Cache cache) {
+        super(instance, regionName, props, metadata, cache);
     }
 
     public NaturalIdRegionAccessStrategy buildAccessStrategy(final AccessType accessType) throws CacheException {


### PR DESCRIPTION
Previously, `HazelcastNaturalIdRegion` was hard coded to create an `IMapRegionCache` even when being created from `HazelcastLocalCacheRegionFactory`.  This change brings natural id regions in line with entity, collection, and timestamp regions.

This change is required only in the `hibernate4` tree, as `hibernate3` does not have natural id caching.