### PR TITLE
BSERVDEV-10734 Fix java.lang.IllegalStateException: invalidate: Session already invalidated errors when a client performs two or more JWT authorized requests at almost the same time.

### DIFF
--- a/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
@@ -479,7 +479,12 @@ public class WebFilter implements Filter {
                     return hazelcastSession;
                 }
                 originalSessions.remove(originalSession.getId());
-                originalSession.invalidate();
+                try {
+                    originalSession.invalidate();
+                } catch (IllegalStateException e) {
+                    // session already invalidated - just ignore
+                    LOGGER.finest("session.invalidate() failed", e);
+                }
             }
             if (clusteredSessionId != null) {
                 hazelcastSession = sessions.get(clusteredSessionId);


### PR DESCRIPTION
This was causing Catalina to respond with an incorrectly chunk coded
message body, which in turn caused apache httpclient - based clients
to fail with the confusing message
"org.apache.http.ConnectionClosedException: Premature end of chunk
coded message body: closing chunk expected".

See https://stash.atlassian.com/projects/AC/repos/atlassian-connect/pull-requests/1053/overview for the exact same issue in Atlassian Connect.