### PR TITLE
BSERVDEV-12943 Fix inconsistencies in LOCAL L2 Hibernate caches after split brain that later heals

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -24,6 +24,7 @@ import com.hazelcast.hibernate.RegionCache;
 import com.hazelcast.hibernate.serialization.Expirable;
 import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.instance.Capability;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.util.Clock;
@@ -40,7 +41,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * Local only {@link com.hazelcast.hibernate.RegionCache} implementation
  * based on a topic to distribute cache updates.
  */
-public class LocalRegionCache implements RegionCache {
+public class LocalRegionCache extends MembershipAdapter implements RegionCache {
 
     private static final long SEC_TO_MS = 1000L;
     private static final int MAX_SIZE = 100000;
@@ -99,6 +100,7 @@ public class LocalRegionCache implements RegionCache {
         } else {
             topic = null;
         }
+        hazelcastInstance.getCluster().addMembershipListener(this);
     }
 
     public Object get(final Object key, long txTimestamp) {
@@ -195,6 +197,16 @@ public class LocalRegionCache implements RegionCache {
                 }
             }
         };
+    }
+
+    @Override
+    public void memberAdded(MembershipEvent membershipEvent)
+    {
+        if (membershipEvent.getMember().getCapabilities().contains(Capability.PARTITION_HOST)) {
+            // Members that have left the cluster and re-joined may be an inconsistent state due to the
+            // potential for "split brain".  So err on the side of safety and flush the local cache.
+            cache.clear();
+        }
     }
 
     public boolean remove(final Object key) {

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -202,7 +202,7 @@ public class LocalRegionCache extends MembershipAdapter implements RegionCache {
     @Override
     public void memberAdded(MembershipEvent membershipEvent)
     {
-        if (membershipEvent.getMember().getCapabilities().contains(Capability.PARTITION_HOST)) {
+        if (membershipEvent.getMember().hasCapability(Capability.PARTITION_HOST)) {
             // Members that have left the cluster and re-joined may be an inconsistent state due to the
             // potential for "split brain".  So err on the side of safety and flush the local cache.
             cache.clear();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.instance.Capability;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -155,6 +156,11 @@ public final class MemberImpl
     @Override
     public void removeAttribute(String key) {
         notSupportedOnClient();
+    }
+
+    @Override
+    public Set<Capability> getCapabilities() {
+        return Collections.emptySet();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -22,7 +22,6 @@ import com.hazelcast.instance.Capability;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -159,8 +158,8 @@ public final class MemberImpl
     }
 
     @Override
-    public Set<Capability> getCapabilities() {
-        return Collections.emptySet();
+    public boolean hasCapability(Capability capability) {
+        return false;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/core/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Member.java
@@ -52,11 +52,12 @@ public interface Member extends DataSerializable, Endpoint {
     InetSocketAddress getInetSocketAddress();
 
     /**
-     * Get the capabilities that this member has in the cluster
-     * @return the capabilities for this member.
+     * Find whether or not the member has a capability
+     * @param capability the capability to check
+     * @return {@code true} if the member has the specified capability, {@code false} otherwise.
      * @since 3.5.2-atlassian-25
      */
-    Set<Capability> getCapabilities();
+    boolean hasCapability(Capability capability);
 
     /**
      * Change the capabilities this member has in the cluster

--- a/hazelcast/src/main/java/com/hazelcast/core/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Member.java
@@ -52,9 +52,16 @@ public interface Member extends DataSerializable, Endpoint {
     InetSocketAddress getInetSocketAddress();
 
     /**
+     * Get the capabilities that this member has in the cluster
+     * @return the capabilities for this member.
+     * @since 3.5.2-atlassian-25
+     */
+    Set<Capability> getCapabilities();
+
+    /**
      * Change the capabilities this member has in the cluster
      * @param capabilities The new capabilities for this member.
-     * @since 3.4
+     * @since 3.3.2-atlassian-5
      */
     void updateCapabilities(Set<Capability> capabilities);
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -95,6 +95,7 @@ public final class MemberImpl
         return logger;
     }
 
+    @Override
     public Set<Capability> getCapabilities() {
         return capabilities;
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -95,7 +95,6 @@ public final class MemberImpl
         return logger;
     }
 
-    @Override
     public Set<Capability> getCapabilities() {
         return capabilities;
     }
@@ -358,6 +357,7 @@ public final class MemberImpl
         return ClusterDataSerializerHook.MEMBER;
     }
 
+    @Override
     public boolean hasCapability(Capability capability) {
         return capabilities.contains(capability);
     }

--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,6 +50,11 @@ public class SimpleMemberImpl implements Member {
     @Override
     public InetSocketAddress getInetSocketAddress() {
         return getSocketAddress();
+    }
+
+    @Override
+    public Set<Capability> getCapabilities() {
+        return Collections.emptySet();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -22,7 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,7 +54,7 @@ public class SimpleMemberImpl implements Member {
 
     @Override
     public Set<Capability> getCapabilities() {
-        return Collections.emptySet();
+        return EnumSet.allOf(Capability.class);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -22,7 +22,6 @@ import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -53,8 +52,8 @@ public class SimpleMemberImpl implements Member {
     }
 
     @Override
-    public Set<Capability> getCapabilities() {
-        return EnumSet.allOf(Capability.class);
+    public boolean hasCapability(Capability capability) {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
The LOCAL L2 Hibernate caches use the `TopicService` for invalidation.  These may become inconsistent if the cluster goes into a "split brain" state that later heals.  This PR fixes this by handling `MemberAddedEvent`s _for members that have the `PARTITION_HOST` capability_ and invalidating the entire L2 cache.

Note that in a typical Hazelcast cluster, all full members have the `PARTITION_HOST` capability, so this errs on the side of caution.  But in a Bitbucket Data Center cluster, newly started cluster nodes with empty initial state actually do not have the `PARTITION_HOST` capability.  Only members which have successfully made it through spring-startup have this capability.  So this is almost certainly only going to trigger invalidation when a running node leaves the cluster and later re-joins, not when new cluster nodes join the cluster from scratch. 

Once this PR merges, I will apply the same test in atlassian-cache `HazelcastAsyncHybridCache`s and any other services in our code base that use the `TopicService` and `memberAdded()` handlers in the same way.