### PR TITLE
BSERVDEV-14356 Removed PartitionService.drain()

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionServiceProxy.java
@@ -162,10 +162,4 @@ public final class PartitionServiceProxy implements PartitionService {
         }
     }
 
-    @Override
-    public boolean drain(long timeout, TimeUnit timeunit) {
-        // Clients  cannot own partitions so there's nothing to drain.
-        return true;
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -151,12 +151,12 @@ public class Config {
     /**
      * Sets the class-loader to be used during de-serialization
      * and as context class-loader of Hazelcast internal threads.
-     * <p>
-     * <p>
+     * <p/>
+     * <p/>
      * If not set (or set to null); thread context class-loader
      * will be used in required places.
-     * <p>
-     * <p>
+     * <p/>
+     * <p/>
      * Default value is null.
      *
      * @param classLoader class-loader to be used during de-serialization

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitionService.java
@@ -167,16 +167,4 @@ public interface PartitionService {
      */
     boolean forceLocalMemberToBeSafe(long timeout, TimeUnit unit);
 
-    /**
-     * Remove all of the partitions currently owned by the local member. Wait for a configurable amount of time
-     * until the local member doesn't own any partitions.
-     * This will cause the local member to loose the PARTITION_HOST capability
-     *
-     * @param timeout The time to wait for the migration before returning.
-     * @param timeunit The unit in which the timeout was provided.
-     * @return true if the local member owns no partition. false otherwise.
-     * @since 3.5.2-atlassian-25
-     */
-    boolean drain(long timeout, TimeUnit timeunit);
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitionService.java
@@ -166,5 +166,4 @@ public interface PartitionService {
      * @since 3.3
      */
     boolean forceLocalMemberToBeSafe(long timeout, TimeUnit unit);
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
@@ -56,7 +56,6 @@ import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 
 import java.util.Collection;
-import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -76,8 +76,6 @@ public interface InternalPartitionService extends IPartitionService {
 
     boolean prepareToSafeShutdown(long timeout, TimeUnit seconds);
 
-    boolean drain(long timeout, TimeUnit timeunit);
-
     InternalPartition[] getInternalPartitions();
 
     void firstArrangement();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
@@ -193,22 +193,6 @@ public class PartitionServiceProxy implements PartitionService {
         return partitionService.getPartitionReplicaStateChecker().triggerAndWaitForReplicaSync(timeout, unit);
     }
 
-    public boolean drain(long timeout, TimeUnit timeunit) {
-        if (timeunit == null) {
-            throw new NullPointerException();
-        }
-
-        if (timeout < 1L) {
-            throw new IllegalArgumentException();
-        }
-
-        if (!nodeActive()) {
-            return true;
-        }
-        return partitionService.drain(timeout, timeunit);
-    }
-
-
     private boolean nodeActive() {
         return nodeEngine.getNode().getState() != NodeState.SHUT_DOWN;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.core.MigrationListener;
-import com.hazelcast.instance.Capability;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
@@ -67,7 +66,6 @@ import com.hazelcast.util.scheduler.ScheduledEntry;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -86,7 +84,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
-import static com.hazelcast.instance.Capability.PARTITION_HOST;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.returnWithDeadline;
 import static java.lang.Math.ceil;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -111,24 +111,16 @@ public class PartitionStateManager {
     }
 
     private Collection<MemberGroup> createMemberGroups() {
-        return memberGroupFactory.createMemberGroups(getPartitionHosts());
-    }
-
-    public Collection<MemberImpl> getPartitionHosts() {
-        // Even though the Master's ClusterServiceImpl prevents a node from dropping the PARTITION_HOST Capability if
-        // there is no other node which can host partitions, at any point in time a node can simply close
-        // the connection and no longer be available. If that's the case the Master will have no choice but to
-        // host the partitions.
-        Collection<MemberImpl> members = node.getClusterService().getMemberList(PARTITION_HOST);
-        if (members.isEmpty()) {
-            members.add(node.getClusterService().getMember(node.getMasterAddress()));
-        }
-        return members;
+        return memberGroupFactory.createMemberGroups(getPartitionHosts(DATA_MEMBER_SELECTOR));
     }
 
     private Collection<MemberImpl> getPartitionHosts(MemberSelector selector) {
         Collection<MemberImpl> members = new ArrayList<MemberImpl>(node.getClusterService().getMemberList(PARTITION_HOST, selector));
         if (members.isEmpty()) {
+            // Even though the Master's ClusterServiceImpl prevents a node from dropping the PARTITION_HOST Capability if
+            // there is no other node which can host partitions, at any point in time a node can simply close
+            // the connection and no longer be available. If that's the case the Master will have no choice but to
+            // host the partitions.
             members.add(node.getClusterService().getMember(node.getMasterAddress()));
         }
         return new MemberSelectingCollection<MemberImpl>(members, selector);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -134,16 +134,6 @@ public class PartitionStateManager {
         return new MemberSelectingCollection<MemberImpl>(members, selector);
     }
 
-    boolean checkIsEmpty() {
-        Address localAddress = node.localMember.getAddress();
-        for (int i = 0; i < partitionCount; i++) {
-            if (localAddress.equals(partitions[i].getOwnerOrNull())) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     boolean initializePartitionAssignments(Set<Address> excludedAddresses) {
         ClusterState clusterState = node.getClusterService().getClusterState();
         if (clusterState != ClusterState.ACTIVE) {

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceLiteMemberTest.java
@@ -5,7 +5,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.Capability;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -15,7 +14,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.partition.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.Capability;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.NoDataMemberInClusterException;
 import com.hazelcast.test.AssertTask;
@@ -32,7 +31,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.fail;
 @Category({QuickTest.class, ParallelTest.class})
 public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport {
 
-    private final Config liteMemberConfig = new Config().setLiteMember(true).setCapabilities(EnumSet.noneOf(Capability.class));
+    private final Config liteMemberConfig = new Config().setLiteMember(true);
 
     /**
      * PARTITION ASSIGNMENT


### PR DESCRIPTION
BSERVDEV-14356 Removed `PartitionService.drain()`.  With the new ["graceful shutdown"](http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#safety-checking-cluster-members) feature in Hazelcast 3.7, this is no longer required.
